### PR TITLE
Add an option to specify the manifest file for development

### DIFF
--- a/largo/bs_command.py
+++ b/largo/bs_command.py
@@ -1,4 +1,5 @@
 from cleo import Command
+from largo.project import Project
 
 
 class BsCommand(Command):
@@ -10,4 +11,5 @@ class BsCommand(Command):
     """
 
     def handle(self):
-        print(self.option('manifest-path'))
+        project = Project(manifest_path=self.option('manifest-path'))
+        print(project)

--- a/largo/bs_command.py
+++ b/largo/bs_command.py
@@ -6,7 +6,8 @@ class BsCommand(Command):
     Show balance sheet
 
     bs
+        {--manifest-path=Largo.toml : The path to a manifest file}
     """
 
     def handle(self):
-        pass
+        print(self.option('manifest-path'))

--- a/largo/project.py
+++ b/largo/project.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+class Project:
+    """
+    Represents a ledger project
+    """
+
+    def __init__(self, manifest_path):
+        self.manifest_path = Path(manifest_path)
+
+    def __str__(self):
+        return f'Project {{ manifest_path: {self.manifest_path} }}'


### PR DESCRIPTION
`--manifest-path` option specifies the path to a manifest file.

The directory where the manifest file exists is the root of the project.

- [x] Add CLI option to class `BsCommand`.
- [x] Add class `Project` which represents a project and contains the manifest path.
- [x] `largo bs` echoes the manifest path back for manual testing.
