### PR TITLE
Rename and refactor `AccountNames`

### DIFF
--- a/largo/project.py
+++ b/largo/project.py
@@ -1,5 +1,6 @@
 import toml
 from pathlib import Path
+from dataclasses import dataclass
 
 
 class Error(Exception):
@@ -29,23 +30,12 @@ class MissingBookError(Error):
         self.path = path
 
 
+@dataclass
 class Account:
     """Wrapper for account names dictionary"""
-
-    def __init__(self, account):
-        self.account = account
-
-    @property
-    def assets(self):
-        return self.account['assets']
-
-    @property
-    def liabilities(self):
-        return self.account['liabilities']
-
-    @property
-    def equity(self):
-        return self.account['equity']
+    assets: str
+    liabilities: str
+    equity: str
 
 
 class Project:
@@ -70,7 +60,7 @@ class Project:
 
     @property
     def account(self):
-        return Account(self.manifest['account'])
+        return Account(**self.manifest['account'])
 
     def check_structure(self):
         """

--- a/largo/project.py
+++ b/largo/project.py
@@ -29,7 +29,7 @@ class MissingBookError(Error):
         self.path = path
 
 
-class AccountName:
+class Account:
     """Wrapper for account names dictionary"""
 
     def __init__(self, account):
@@ -70,7 +70,7 @@ class Project:
 
     @property
     def account(self):
-        return AccountName(self.manifest['account'])
+        return Account(self.manifest['account'])
 
     def check_structure(self):
         """


### PR DESCRIPTION
The name of the class `AccountNames` is renamed to `Account`. It is
refactored with `dataclass` and check if the fields exists in the
given manifest.

Parent: #2
