### PR TITLE
Fix missing import in _largo/pl_command.py_

### DIFF
--- a/largo/pl_command.py
+++ b/largo/pl_command.py
@@ -1,5 +1,4 @@
 from cleo import Command
-from largo import Month
 from largo.date_range import DateRange
 from largo.project import Project
 from largo.profit_loss import ProfitLoss


### PR DESCRIPTION
The following error is fixed:
```
/Users/shotaro/projects/largo/largo/pl_command.py:2:19 - error: "Month" is unknown import symbol (reportGeneralTypeIssues)
```
